### PR TITLE
Add Eye of GNOME

### DIFF
--- a/org.gnome.Characters.json
+++ b/org.gnome.Characters.json
@@ -1,0 +1,50 @@
+{
+    "app-id": "org.gnome.Characters",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "master",
+    "sdk": "org.gnome.Sdk",
+    "strip": false,
+    "finish-args": ["--share=ipc", "--socket=x11", "--socket=pulseaudio", "--share=network", "--talk-name=ca.desrt.dconf"],
+    "build-options" : {
+        "cflags": "-O2 -g",
+        "cxxflags": "-O2 -g"
+    },
+    "cleanup": ["/include", "/lib/pkgconfig",
+                "/share/pkgconfig", "/share/aclocal",
+                "/man", "/share/man", "/share/gtk-doc",
+                "*.la", "*.a",
+                "/share/dbus-1", "/share/doc", "/share/gir-1.0"
+    ],
+    "modules": [
+        {
+            "name": "autoconf-archive",
+            "cleanup": ["*"],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://ftp.acc.umu.se/mirror/gnu.org/gnu/autoconf-archive/autoconf-archive-2015.09.25.tar.xz",
+                    "sha256": "7c0467a5dbd2340153bca5a477bd92fbc951d9ee3cbed92f16f6bf08ac0c350a"
+                }
+            ]
+        },
+        {
+            "name": "gnome-desktop",
+            "config-opts": ["--disable-debug-tools"],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "git://git.gnome.org/gnome-desktop"
+                }
+            ]
+        },
+        {
+            "name": "gnome-characters",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "git://git.gnome.org/gnome-characters"
+                }
+            ]
+        }
+    ]
+}

--- a/org.gnome.eog.json
+++ b/org.gnome.eog.json
@@ -1,0 +1,78 @@
+{
+    "app-id": "org.gnome.eog",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "master",
+    "sdk": "org.gnome.Sdk",
+    "strip": false,
+    "command": "eog",
+    "rename-desktop-file": "eog.desktop",
+    "rename-appdata-file": "eog.appdata.xml",
+    "rename-icon": "eog",
+    "finish-args": ["--share=ipc", "--socket=x11", "--socket=pulseaudio", "--filesystem=host", "--talk-name=ca.desrt.dconf"],
+    "build-options" : {
+        "cflags": "-O2 -g",
+        "cxxflags": "-O2 -g",
+        "env": {
+            "V": "1"
+        }
+    },
+    "cleanup": ["/include", "/lib/pkgconfig",
+                "/share/pkgconfig", "/share/aclocal",
+                "/man", "/share/man", "/share/gtk-doc",
+                "*.la", "*.a"],
+    "modules": [
+        {
+            "name": "autoconf-archive",
+            "cleanup": ["*"],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://ftp.acc.umu.se/mirror/gnu.org/gnu/autoconf-archive/autoconf-archive-2015.09.25.tar.xz",
+                    "sha256": "7c0467a5dbd2340153bca5a477bd92fbc951d9ee3cbed92f16f6bf08ac0c350a"
+                }
+            ]
+        },
+        {
+            "name": "shared-mime-info",
+            "cleanup": [ "/bin/*" ],
+            "config-opts": ["--disable-default-make-check"],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "git://anongit.freedesktop.org/git/xdg/shared-mime-info"
+                }
+            ]
+        },
+        {
+            "name": "gnome-desktop",
+            "config-opts": ["--disable-debug-tools"],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "git://git.gnome.org/gnome-desktop"
+                }
+            ]
+        },
+        {
+            "name": "libpeas",
+            "cleanup": [ "/bin/*", "/lib/peas-demo" ],
+            "config-opts": [ ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "git://git.gnome.org/libpeas"
+                }
+            ]
+        },
+        {
+            "name": "eog",
+            "config-opts": [ ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "git://git.gnome.org/eog"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Bundles shared-mime-info while the freedesktop SDK gets rebuilt; I can update the PR later on, if you don't want to merge it right now.
