### PR TITLE
Fix dependency of Epiphany

### DIFF
--- a/org.gnome.Epiphany.json
+++ b/org.gnome.Epiphany.json
@@ -1,6 +1,6 @@
 {
     "app-id": "org.gnome.Epiphany",
-    "runtime": "org.gnome.Sdk",
+    "runtime": "org.gnome.Platform",
     "runtime-version": "master",
     "sdk": "org.gnome.Sdk",
     "strip": false,


### PR DESCRIPTION
Don't depend on the SDK as the runtime.
