### PR TITLE
maps: Enable talk on org.freedesktop.secrets

### DIFF
--- a/org.gnome.Maps.json
+++ b/org.gnome.Maps.json
@@ -21,6 +21,8 @@
         "--talk-name=org.gnome.evolution.dataserver.Calendar7",
         "--talk-name=org.gnome.evolution.dataserver.Sources5",
         "--talk-name=org.gnome.evolution.dataserver.Subprocess.Backend.*",
+        /* Needed to save OAuth token from OpenStreetMap */
+        "--talk-name=org.freedesktop.secrets",
         /* Needed to get geo-positioning */
         "--system-talk-name=org.freedesktop.GeoClue2",
         /* Needed for dconf to work (unfortunately needs homedir read access) */


### PR DESCRIPTION
Needed to store OAuth token from OpenStreetMap.
