### PR TITLE
games: Remove jsk

### DIFF
--- a/org.gnome.Games.json
+++ b/org.gnome.Games.json
@@ -67,15 +67,6 @@
             ]
         },
         {
-            "name": "jsk",
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://github.com/Kekun/jsk"
-                }
-            ]
-        },
-        {
             "name": "gnome-games",
             "sources": [
                 {


### PR DESCRIPTION
This is necessary as jsk have been deprecated and unused.
