### PR TITLE
games: Remove retro-gobject

### DIFF
--- a/org.gnome.Games.json
+++ b/org.gnome.Games.json
@@ -32,11 +32,11 @@
     ],
     "modules": [
         {
-            "name": "retro-gobject",
+            "name": "retro-gtk",
             "sources": [
                 {
                     "type": "git",
-                    "url": "https://github.com/Kekun/retro-gobject"
+                    "url": "https://github.com/Kekun/retro-gtk"
                 }
             ]
         },
@@ -46,15 +46,6 @@
                 {
                     "type": "git",
                     "url": "https://github.com/Kekun/retro-plugins"
-                }
-            ]
-        },
-        {
-            "name": "retro-gtk",
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://github.com/Kekun/retro-gtk"
                 }
             ]
         },


### PR DESCRIPTION
Necessary as retro-gobject have been moved to retro-gtk's repository.
