### PR TITLE
Allow epiphany talk to the org.freedesktop.GeoClue2 D-Bus service

### DIFF
--- a/org.gnome.Epiphany.json
+++ b/org.gnome.Epiphany.json
@@ -19,6 +19,8 @@
         "--share=network",
         /* Play sounds */
         "--socket=pulseaudio",
+        /* Allow using the HTML5 Geolocation API */
+        "--system-talk-name=org.freedesktop.GeoClue2",
         /* Needed for dconf to work */
         "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
         "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf"


### PR DESCRIPTION
This is needed for getting the HTML5 Geolocation API to work.
