### PR TITLE
org.gnome.Builder: Remove "rename-icon" line

### DIFF
--- a/org.gnome.Builder.json
+++ b/org.gnome.Builder.json
@@ -4,7 +4,6 @@
     "runtime-version": "master",
     "sdk": "org.gnome.Sdk",
     "command": "gnome-builder",
-    "rename-icon": "builder",
     "tags": ["nightly"],
     "desktop-file-name-prefix": "(Nightly) ",
     "finish-args": [


### PR DESCRIPTION
GNOME Builder's icon has been renamed to its app id in
6dadb2230acba3705474e4689d15ed94b5136239, so it no longer needs to be
renamed for the flatpak build.
