### PR TITLE
Update org.gnome.Calculator.json for renamed desktop entry.

### DIFF
--- a/org.gnome.Calculator.json
+++ b/org.gnome.Calculator.json
@@ -5,7 +5,6 @@
     "sdk": "org.gnome.Sdk",
     "command": "gnome-calculator",
     "tags": ["nightly"],
-    "rename-desktop-file": "gnome-calculator.desktop",
     "desktop-file-name-prefix": "(Nightly) ",
     "finish-args": [
         /* X11 + XShm access */


### PR DESCRIPTION
Don't really know where else to contribute this to, so I decided to create a PR here.

See [bug 775056](https://bugzilla.gnome.org/show_bug.cgi?id=775056) for the accompanying bug.